### PR TITLE
fix: log actual Elasticsearch endpoint when ELASTIC_URI is set

### DIFF
--- a/src/app.cr
+++ b/src/app.cr
@@ -182,7 +182,7 @@ else
 
   Log.info { "Launching #{SearchIngest::APP_NAME} v#{SearchIngest::VERSION}" }
   Log.info { "With PostgreSQL Database \"#{pg_db}\" on #{PgORM::Database.settings.host}:#{PgORM::Database.settings.port}" }
-  Log.info { "With Elasticsearch on #{SearchIngest::Elastic.settings.host}:#{SearchIngest::Elastic.settings.port}" }
+  Log.info { "With Elasticsearch on #{SearchIngest::Elastic.settings.uri.try(&.host) || SearchIngest::Elastic.settings.host}:#{SearchIngest::Elastic.settings.uri.try(&.port) || SearchIngest::Elastic.settings.port}" }
   Log.info { "Mirroring #{SearchIngest::MANAGED_TABLES.map(&.name).sort!.join(", ")}" }
 
   # Start API's TableManager instance

--- a/src/search-ingest.cr
+++ b/src/search-ingest.cr
@@ -11,12 +11,12 @@ module SearchIngest
       max_elapsed_time: 1.minute
     ) do
       attempt += 1
-      Log.warn { "attempt #{attempt} connecting to #{SearchIngest::Elastic.settings.host}:#{SearchIngest::Elastic.settings.port}" } if attempt > 1
+      Log.warn { "attempt #{attempt} connecting to #{SearchIngest::Elastic.settings.uri.try(&.host) || SearchIngest::Elastic.settings.host}:#{SearchIngest::Elastic.settings.uri.try(&.port) || SearchIngest::Elastic.settings.port}" } if attempt > 1
 
       # Ensure elastic is available
       raise "retry" unless SearchIngest::Elastic.healthy?
     end
   rescue
-    abort("Failed to connect to Elasticsearch on #{SearchIngest::Elastic.settings.host}:#{SearchIngest::Elastic.settings.port}")
+    abort("Failed to connect to Elasticsearch on #{SearchIngest::Elastic.settings.uri.try(&.host) || SearchIngest::Elastic.settings.host}:#{SearchIngest::Elastic.settings.uri.try(&.port) || SearchIngest::Elastic.settings.port}")
   end
 end


### PR DESCRIPTION
The startup/retry/abort log lines read settings.host:settings.port, which default to localhost:9200 even when the URI is what drives the connection, making real failures look like a localhost issue.